### PR TITLE
merge LCPP-111 into dev (Collapsible Sidebar)

### DIFF
--- a/web_app/src/components/Layout.jsx
+++ b/web_app/src/components/Layout.jsx
@@ -114,7 +114,7 @@ const deleteAllChats = () => {
         <button 
           class={styles.toggleSidebarButton}
           onClick={toggleSidebar}
-          title={sidebarCollapsed() ? "Show sidebar" : "Hide sidebar"}
+          title={sidebarCollapsed() ? "expand sidebar" : "collapse sidebar"}
         >
           {sidebarCollapsed() ? '→' : '←'}
         </button>

--- a/web_app/src/components/Layout.jsx
+++ b/web_app/src/components/Layout.jsx
@@ -27,7 +27,15 @@ function Layout(props) {
   // hover state for mouse navigation of chats
   const [hoveredChatId, setHoveredChatId] = createSignal(null);
   
+  // sidebar collapse state
+  const [sidebarCollapsed, setSidebarCollapsed] = createSignal(false);
+  
   const pageContent = props.children;
+  
+  // toggle sidebar function
+  const toggleSidebar = () => {
+    setSidebarCollapsed(!sidebarCollapsed());
+  };
   
   // updates the chat history
   createEffect(() => {
@@ -101,8 +109,17 @@ const deleteAllChats = () => {
 
   return (
     <>
-      <div class="container">
-        <div class="sidebarContainer">
+      <div class={sidebarCollapsed() ? "container sidebar-collapsed" : "container"}>
+        {/* collapse toggle button */}
+        <button 
+          class={styles.toggleSidebarButton}
+          onClick={toggleSidebar}
+          title={sidebarCollapsed() ? "Show sidebar" : "Hide sidebar"}
+        >
+          {sidebarCollapsed() ? '→' : '←'}
+        </button>
+
+        <div class={sidebarCollapsed() ? "sidebarContainer collapsed" : "sidebarContainer"}>
 
           <h1>Local Chat</h1>
           <A href="models">Model Testing</A>

--- a/web_app/src/components/Layout.module.css
+++ b/web_app/src/components/Layout.module.css
@@ -236,3 +236,23 @@
     background-color: var(--selected-button-colour);
     transform: scale(0.95);
 }
+
+/* sidebar toggle button */
+.toggleSidebarButton {
+    position: fixed;
+    left: 0;
+    top: 20px;
+    z-index: 1000;
+    background: var(--selected-button-colour);
+    border: 1px solid var(--highlight-colour);
+    padding: 8px 12px;
+    border-radius: 0 6px 6px 0;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    color: var(--text-colour);
+    font-size: 16px;
+}
+
+.toggleSidebarButton:hover {
+    background: var(--highlight-colour);
+}

--- a/web_app/src/components/Layout.module.css
+++ b/web_app/src/components/Layout.module.css
@@ -241,14 +241,16 @@
 .toggleSidebarButton {
     position: fixed;
     left: 0;
-    top: 29px;
+    top: 31px;
     z-index: 1000;
     background: var(--selected-button-colour);
     border: 1px solid var(--highlight-colour);
     padding: 8px 12px;
+    border-radius: 0 6px 6px 0;
+    cursor: pointer;
     transition: all 0.3s ease;
     color: var(--text-colour);
-    font-size: 20px;
+    font-size: 14px;
 }
 
 .toggleSidebarButton:hover {

--- a/web_app/src/components/Layout.module.css
+++ b/web_app/src/components/Layout.module.css
@@ -237,20 +237,18 @@
     transform: scale(0.95);
 }
 
-/* sidebar toggle button */
+/* sidebar toggle button positioning */
 .toggleSidebarButton {
     position: fixed;
     left: 0;
-    top: 20px;
+    top: 29px;
     z-index: 1000;
     background: var(--selected-button-colour);
     border: 1px solid var(--highlight-colour);
     padding: 8px 12px;
-    border-radius: 0 6px 6px 0;
-    cursor: pointer;
     transition: all 0.3s ease;
     color: var(--text-colour);
-    font-size: 16px;
+    font-size: 20px;
 }
 
 .toggleSidebarButton:hover {

--- a/web_app/src/index.css
+++ b/web_app/src/index.css
@@ -25,6 +25,7 @@
 
 body {
   margin: 0;
+  background-color: var(--background-primary);
 }
 
 .container {
@@ -77,4 +78,36 @@ button:hover, .inputButton:hover {
 
 .hidden {
   display: none;
+}
+
+/* container size for collapse button and smoother transition */
+.container {
+  display: grid;
+  grid-template-areas:
+    "sidebar pageArea";
+  grid-template-columns: 20% auto;
+  height: 100vh;
+  transition: grid-template-columns 0.3s ease;
+}
+
+/* when collapsed sidebar = 0px and will autofill the rest of the screen */
+.container.sidebar-collapsed {
+  grid-template-columns: 0px 1fr;
+}
+
+/* smooth slide animation when collapsing/expanding */
+.sidebarContainer {
+  transition: transform 0.3s ease;
+  overflow: hidden;
+}
+
+/* slide sidebar completely off screen when collapsed */
+.sidebarContainer.collapsed {
+  transform: translateX(-100%);
+}
+
+/* main page content area */
+.pageContainer {
+  grid-area: pageArea;  
+  background-color: var(--background-primary);
 }


### PR DESCRIPTION
Implemented a feature to collapse the sidebar, the feature is functionally complete but i would like to continue to make some other CSS changes as the button looks a bit haphazard in its implementation. But I will task this for the next sprint where we focus essentially purely on completing any small changes to the webapp.

so for now it looks like this (as per normal) when uncollapsed:
<img width="3024" height="1646" alt="image" src="https://github.com/user-attachments/assets/2f731445-ad3c-48fb-88ef-7a199dcacc12" />

and like this when collapsed:
<img width="3024" height="1648" alt="image" src="https://github.com/user-attachments/assets/d7653e22-e632-4e88-a76e-dc3ac9707e95" />

this also transfers and scales properly with other functions like for example in summarisation:
<img width="3024" height="1642" alt="image" src="https://github.com/user-attachments/assets/d2212ee2-3e24-46fd-9fb3-9b7b3a2a78ae" />

Now I am aware that the button does overlap other buttons like the cpu/gpu selector normally reserved for the top right and this is by design as I have hard coded a Zpos for the button meaning it will always sit on top of **everything**. I intend to look for more graceful solution but it the meantime this is how it looks (unfortunately).

